### PR TITLE
Adding an option for a trailing argument to cron_rscript.R

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,4 +22,4 @@ License: MIT + file LICENSE
 VignetteBuilder: knitr
 OS_type: unix
 SystemRequirements: cron
-RoxygenNote: 6.0.1
+RoxygenNote: 7.1.1

--- a/R/cron_rscript.R
+++ b/R/cron_rscript.R
@@ -49,7 +49,7 @@ cron_rscript <- function(rscript,
   }
   
   if(!is.null(trailing_arg)){
-    cmd <- sprintf("%s %s %s %s", cmd, "&&", shQuote(trailing_arg))
+    cmd <- sprintf("%s %s %s", cmd, "&&", trailing_arg)
    }
   
   cmd

--- a/R/cron_rscript.R
+++ b/R/cron_rscript.R
@@ -8,6 +8,7 @@
 #' @param log_timestamp logical, indicating to append a timestamp to the script log filename in the default argument of \code{rscript_log}. 
 #' This will only work if the path to the log folder does not contain spaces.
 #' @param workdir If provided, Rscript will be run from this working directory.
+#' @param trailing_arg If provided, this is added to the end of the command
 #' @return a character string with a command which can e.g. be put as a cronjob for running a simple R script at specific timepoints
 #' @export
 #' @examples
@@ -29,7 +30,8 @@ cron_rscript <- function(rscript,
                          cmd = file.path(Sys.getenv("R_HOME"), "bin", "Rscript"),
                          log_append = TRUE,
                          log_timestamp = FALSE,
-                         workdir = NULL) {
+                         workdir = NULL,
+                         trailing_arg = NULL) {
   stopifnot(file.exists(rscript))
   if(length(rscript_args) > 0){
     rscript_args <- paste(rscript_args, collapse = " ")
@@ -45,5 +47,10 @@ cron_rscript <- function(rscript,
   if(!is.null(workdir)){
     cmd <- sprintf("%s %s %s %s",  "cd", shQuote(workdir), "&&", cmd)
   }
+  
+  if(!is.null(trailing_arg)){
+    cmd <- sprintf("%s %s %s %s", cmd, "&&", shQuote(trailing_arg))
+   }
+  
   cmd
 }

--- a/man/cron_add.Rd
+++ b/man/cron_add.Rd
@@ -5,11 +5,33 @@
 \alias{cronjob}
 \title{Make a simple cron job}
 \usage{
-cron_add(command, frequency = "daily", at, days_of_month, days_of_week,
-  months, id, tags = "", description = "", dry_run = FALSE, user = "")
+cron_add(
+  command,
+  frequency = "daily",
+  at,
+  days_of_month,
+  days_of_week,
+  months,
+  id,
+  tags = "",
+  description = "",
+  dry_run = FALSE,
+  user = ""
+)
 
-cronjob(command, frequency = "daily", at, days_of_month, days_of_week, months,
-  id, tags = "", description = "", dry_run = FALSE, user = "")
+cronjob(
+  command,
+  frequency = "daily",
+  at,
+  days_of_month,
+  days_of_week,
+  months,
+  id,
+  tags = "",
+  description = "",
+  dry_run = FALSE,
+  user = ""
+)
 }
 \arguments{
 \item{command}{A command to execute.}

--- a/man/cron_rscript.Rd
+++ b/man/cron_rscript.Rd
@@ -12,7 +12,8 @@ cron_rscript(
   cmd = file.path(Sys.getenv("R_HOME"), "bin", "Rscript"),
   log_append = TRUE,
   log_timestamp = FALSE,
-  workdir = NULL
+  workdir = NULL,
+  trailing_arg = NULL
 )
 }
 \arguments{
@@ -30,6 +31,8 @@ cron_rscript(
 This will only work if the path to the log folder does not contain spaces.}
 
 \item{workdir}{If provided, Rscript will be run from this working directory.}
+
+\item{trailing_arg}{If provided, this is added to the end of the command}
 }
 \value{
 a character string with a command which can e.g. be put as a cronjob for running a simple R script at specific timepoints


### PR DESCRIPTION
Services to monitor cron jobs, like Healthchecks.io, require adding an command to the cron job command.  For example, 

`cd '/home/rstudio/Documents/scripts/neon4cast-scoring' && /usr/local/lib/R/bin/Rscript '/home/rstudio/Documents/scripts/neon4cast-scoring/scoring.R'  > '/efi_neon_challenge/log/cron/scoring.log' 2>&1 && curl -fsS -m 10 --retry 5 -o /dev/null https://hc-ping.com/1dd67f13-3a08-4a2b-86a3-6f13cb36baca`

has the `curl -fsS -m 10 --retry 5 -o /dev/null https://hc-ping.com/1dd67f13-3a08-4a2b-86a3-6f13cb36baca` at the end of the command.  Currently, `cron_rscript.R` does not support adding a command like this after part of the command that sends the R output to the log. 

To support this, I added an optional argument to cron_script.R called `trailing_arg` that will add the string to the end of the command - always after the log assignment.

`if(!is.null(trailing_arg)){
    cmd <- sprintf("%s %s %s", cmd, "&&", trailing_arg)
   }
`
