### PR TITLE
fix: set default RscriptRepository path to current working directory

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,4 +22,4 @@ License: MIT + file LICENSE
 VignetteBuilder: knitr
 OS_type: unix
 SystemRequirements: cron
-RoxygenNote: 6.0.1
+RoxygenNote: 7.1.1

--- a/R/cron_rstudioaddin.R
+++ b/R/cron_rstudioaddin.R
@@ -179,7 +179,7 @@ cron_rstudioaddin <- function(RscriptRepository = Sys.getenv("CRON_LIVE", unset 
       }
       
       if (!file.exists(RscriptRepository)) {
-        stop(sprintf("The specified Rscript repository path does not exist. Please set it to an existing directory."))
+        stop(sprintf("The specified Rscript repository path, at %s, does not exist. Please set it to an existing directory.", RscriptRepository))
       }
       
       runme <- getSelectedFile(inputui = input$fileSelect)

--- a/R/cron_rstudioaddin.R
+++ b/R/cron_rstudioaddin.R
@@ -4,14 +4,14 @@
 #' 
 #' @param RscriptRepository path to the folder where R scripts will be copied to and launched from,
 #' and log files will be written to.
-#' Defaults to the current working directory. Can be set with the \code{CRON_LIVE} environment variable.
+#' Defaults to the current working directory. Can also be set with the \code{CRON_LIVE} environment variable.
 #' @return the return of \code{\link[shiny]{runGadget}}
 #' @export
 #' @examples 
 #' \dontrun{
 #' cron_rstudioaddin()
 #' }
-cron_rstudioaddin <- function(RscriptRepository) {
+cron_rstudioaddin <- function(RscriptRepository = Sys.getenv("CRON_LIVE", unset = getwd())) {
   
   cron_current <- function(){
     x <- try(parse_crontab(), silent = TRUE)
@@ -24,13 +24,6 @@ cron_rstudioaddin <- function(RscriptRepository) {
   requireNamespace("shiny")
   requireNamespace("miniUI")
   requireNamespace("shinyFiles")
-
-  # set the directory where R scripts will be copied to and launched from.
-  # if no repo is provided, look for CRON_LIVE environment variable; if that's not found,
-  # default to working directory.
-  if(missing(RscriptRepository)){
-    RscriptRepository <- Sys.getenv("CRON_LIVE", unset = getwd())
-  }
 
   check <- NULL
   
@@ -184,6 +177,11 @@ cron_rstudioaddin <- function(RscriptRepository) {
       if(length(grep(" ", RscriptRepository)) > 0){
         warning(sprintf("It is advised that the RscriptRepository does not contain spaces, change argument %s to another location on your drive which contains no spaces", RscriptRepository))
       }
+      
+      if (!file.exists(RscriptRepository)) {
+        stop(sprintf("The specified Rscript repository path does not exist. Please set it to an existing directory."))
+      }
+      
       runme <- getSelectedFile(inputui = input$fileSelect)
       myscript <- paste0(RscriptRepository, "/", basename(runme))
       if(runme != myscript){

--- a/R/cron_rstudioaddin.R
+++ b/R/cron_rstudioaddin.R
@@ -1,4 +1,3 @@
-
 #' @title Launch an RStudio addin which allows to schedule an Rscript interactively.
 #' @description Launch an RStudio addin which allows to schedule an Rscript interactively.
 #' 
@@ -139,12 +138,14 @@ cron_rstudioaddin <- function(RscriptRepository = Sys.getenv("CRON_LIVE", unset 
     #                    multiple = FALSE)
     # })
     
-    # When path to Rscript repository has been changed
-    shiny::observeEvent(input$rscript_repository, {
+    # when path to Rscript repository has been changed, wait 1 second (to avoid
+    # spamming output with messages), then check for existence of path and write permissions.
+    # also normalize RscriptRepository path in parent environment.
+    rscript_repo_observer <- reactive(input$rscript_repository)
+    rscript_repo_observer_delay <- debounce(rscript_repo_observer, 1000)
+    shiny::observeEvent(rscript_repo_observer_delay(), {
       RscriptRepository <<- normalizePath(input$rscript_repository, winslash = "/")
-      if(is.na(file.info(RscriptRepository)$isdir)){
-        message(sprintf("RscriptRepository %s does not exist, make sure this is an existing directory without spaces", RscriptRepository))
-      }
+      verify_rscript_path(RscriptRepository)
     })
     
     ###########################

--- a/R/verify_rscript_path.R
+++ b/R/verify_rscript_path.R
@@ -1,0 +1,14 @@
+#' @title Verify RscriptRespository path.
+#' @description Verify that the supplied RscriptRepository path exists and that the user
+#' has write access.
+#' @param RscriptRepository Value of input$rscript_repository.
+#' @return A warning if RscriptRepository path doesn't exist, or if the user
+#' doesn't have write access; else, no return value.
+verify_rscript_path <- function(RscriptRepository) {
+  # first check whether path exists; if it does, then check whether you have write permission.
+  if(is.na(file.info(RscriptRepository)$isdir)){
+    warning(sprintf("The specified Rscript repository path %s does not exist, make sure this is an existing directory without spaces.", RscriptRepository))
+  } else if (as.logical(file.access(RscriptRepository, mode = 2))) {
+    warning(sprintf("You do not have write access to the specified Rscript repository path, %s.", RscriptRepository))
+  }
+}

--- a/README.md
+++ b/README.md
@@ -3,15 +3,15 @@ cronR
 
 ![cronR](vignettes/cronR-logo.png) 
 
-Schedule R scripts/processes with the cron scheduler. This allows R users working on Unix/Linux to automate R processes on specific timepoints from R itself.
-Mark that if you are looking for a Windows scheduler, you might be interested in the R package taskscheduleR available at
+Schedule R scripts/processes with the cron scheduler. This allows R users working on Unix/Linux to automate R processes at specific timepoints from R itself.
+Note that if you are looking for a Windows scheduler, you might be interested in the R package taskscheduleR available at
 https://github.com/bnosac/taskscheduleR
 
 
 Basic usage
 -----------
 
-This R package allows to 
+This R package allows you to 
 
 * Get the list of scheduled jobs
 * Remove scheduled jobs
@@ -20,16 +20,26 @@ This R package allows to
   + You can schedule tasks 'ONCE', 'EVERY MINUTE', 'EVERY HOUR', 'EVERY DAY', 'EVERY WEEK', 'EVERY MONTH' or any complex schedule
   + The task log contains the stdout & stderr of the Rscript which was run on that timepoint. This log can be found at the same folder as the R script
 
-When the task has run which is scheduled with the RStudio addin, you can look at the log which contains everything from stdout and stderr. The log file is located at the directory where the R script is located.
-
-
 RStudio add-in
 -----------
 
-The package contains also an RStudio add-in. If you install the package and use RStudio version 0.99.893 or later you can just click to schedule a task. Just click Addins > Schedule R scripts on Linux/Unix.
+The package also contains an RStudio addin. If you install the package and use RStudio version 0.99.893 or later you can just click to schedule a task. Just click Addins > Schedule R scripts on Linux/Unix.
 
 ![cronR](vignettes/cronR-rstudioaddin.png) 
 
+Alternatively, run `cronR::cron_rstudioaddin()` to open the addin interface.
+
+If you use the addin, by default, the scheduled script will be copied (and a logfile of the same name will be created) in the current working directory. A different directory can be specified by passing an argument to the `RscriptRepository` parameter:
+
+```
+cronR::cron_rstudioaddin(RscriptRepository = "/path/to/directory/")
+```
+
+You can also set the `CRON_LIVE` environment variable to specify a default directory to copy scheduled scripts and logfiles to. This can be done by manually adding an entry in the [Renviron or Renviron.site files](https://support.rstudio.com/hc/en-us/articles/360047157094-Managing-R-with-Rprofile-Renviron-Rprofile-site-Renviron-site-rsession-conf-and-repos-conf). You can easily do this by running `usethis::edit_r_environ()`, and adding an entry as follows:
+
+```
+CRON_LIVE="/path/to/directory/"
+```
 
 Usage
 -----------

--- a/man/cron_add.Rd
+++ b/man/cron_add.Rd
@@ -5,11 +5,33 @@
 \alias{cronjob}
 \title{Make a simple cron job}
 \usage{
-cron_add(command, frequency = "daily", at, days_of_month, days_of_week,
-  months, id, tags = "", description = "", dry_run = FALSE, user = "")
+cron_add(
+  command,
+  frequency = "daily",
+  at,
+  days_of_month,
+  days_of_week,
+  months,
+  id,
+  tags = "",
+  description = "",
+  dry_run = FALSE,
+  user = ""
+)
 
-cronjob(command, frequency = "daily", at, days_of_month, days_of_week, months,
-  id, tags = "", description = "", dry_run = FALSE, user = "")
+cronjob(
+  command,
+  frequency = "daily",
+  at,
+  days_of_month,
+  days_of_week,
+  months,
+  id,
+  tags = "",
+  description = "",
+  dry_run = FALSE,
+  user = ""
+)
 }
 \arguments{
 \item{command}{A command to execute.}

--- a/man/cron_rstudioaddin.Rd
+++ b/man/cron_rstudioaddin.Rd
@@ -7,7 +7,9 @@
 cron_rstudioaddin(RscriptRepository)
 }
 \arguments{
-\item{RscriptRepository}{path to the folder where R scripts will be copied to and launched. Defaults to the extdata folder in the cronR R library}
+\item{RscriptRepository}{path to the folder where R scripts will be copied to and launched from,
+and log files will be written to.
+Defaults to the current working directory. Can be set with the \code{CRON_LIVE} environment variable.}
 }
 \value{
 the return of \code{\link[shiny]{runGadget}}

--- a/tests/testthat/test-verify_script_path.R
+++ b/tests/testthat/test-verify_script_path.R
@@ -1,0 +1,13 @@
+test_that("verify_rscript_path shows warning messages correctly", {
+
+  expect_warning(
+    verify_rscript_path("/opt"),
+    "You do not have write access to the specified Rscript repository path, /opt."
+  )
+  
+  expect_warning(
+    verify_rscript_path("/DirClearlyDoesNotExist"),
+    "The specified Rscript repository path /DirClearlyDoesNotExist does not exist, make sure this is an existing directory without spaces."
+  )
+  
+})


### PR DESCRIPTION
If no `RscriptRepository` path is provided to `cron_rstudioaddin`, the environment variable `CRON_LIVE` will be tried. If that's not set, it defaults to the current working directory. Removes previous process of writing to the package's extdata folder.