### PR TITLE
Support setting environment variable for cron jobs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: cronR
 Type: Package
 Title: Schedule R Scripts and Processes with the 'cron' Job Scheduler
-Version: 0.6.0
+Version: 0.6.1
 Authors@R: c(
     person("Jan", "Wijffels", role = c("aut", "cre", "cph"), email = "jwijffels@bnosac.be"), 
     person("BNOSAC", role = "cph"), 

--- a/R/cron_add.R
+++ b/R/cron_add.R
@@ -200,7 +200,7 @@ cron_add <- function(command, frequency="daily", at, days_of_month, days_of_week
     paste0("## id:   ", id),
     paste0("## tags: ", paste(tags, collapse=", ")),
     paste0("## desc: ", description),
-    if (length(env) > 0L) paste(paste0(names(env), "=", env), collapse = "\n")
+    if (length(env) > 0L) paste(paste(names(env), env, sep = "="), collapse = "\n")
   )
   if(frequency %in% c("minutely", "hourly", "daily", "monthly", "yearly")){
     job_str <- paste( sep="\n", collapse="\n",

--- a/R/cron_add.R
+++ b/R/cron_add.R
@@ -39,6 +39,8 @@
 #'   instead we return the parsed text that would be submitted as a cron job.
 #' @param user The user whose cron jobs we wish to examine.
 #' @param ask Boolean; show prompt asking for validation
+#' @param env Named character; set environment variables for a cron job.
+#'   Specify `Sys.getenv()` to inherit the variables from the current R session.
 #' @export
 #' @examples 
 #' \dontshow{if(interactive())
@@ -76,8 +78,11 @@
 #' \}
 #' }
 cron_add <- function(command, frequency="daily", at, days_of_month, days_of_week, months,
-  id, tags="", description="", dry_run=FALSE, user="", ask=TRUE) {
+  id, tags="", description="", dry_run=FALSE, user="", ask=TRUE, env=character()) {
   
+  if (length(env) > 0L && is.null(names(env))) {
+    stop("The argument `env` must be a named vector.")
+  }
   crontab <- tryCatch(parse_crontab(user=user),
     error=function(e) {
       return( character() )
@@ -194,7 +199,8 @@ cron_add <- function(command, frequency="daily", at, days_of_month, days_of_week
     "## cronR job",
     paste0("## id:   ", id),
     paste0("## tags: ", paste(tags, collapse=", ")),
-    paste0("## desc: ", description)
+    paste0("## desc: ", description),
+    if (length(env) > 0L) paste(paste0(names(env), "=", env), collapse = "\n")
   )
   if(frequency %in% c("minutely", "hourly", "daily", "monthly", "yearly")){
     job_str <- paste( sep="\n", collapse="\n",

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -1,6 +1,10 @@
 Package: cronR
 ================
 
+Version: UNRELEASED
+
+- cron_add gains an argument, env, which sets environment variables for a cron job by a named vector.
+
 Version: 0.6.0 [2021-09-02]
 
 - Make sure always ask for approval when executing cron_add, cron_rm, cron_clear unless explicitely indicating ask=FALSE

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -1,7 +1,7 @@
 Package: cronR
 ================
 
-Version: UNRELEASED
+Version: 0.6.1 [2021-01-27]
 
 - cron_add gains an argument, env, which sets environment variables for a cron job by a named vector.
 

--- a/man/cron_add.Rd
+++ b/man/cron_add.Rd
@@ -17,7 +17,8 @@ cron_add(
   description = "",
   dry_run = FALSE,
   user = "",
-  ask = TRUE
+  ask = TRUE,
+  env = character()
 )
 
 cronjob(
@@ -32,7 +33,8 @@ cronjob(
   description = "",
   dry_run = FALSE,
   user = "",
-  ask = TRUE
+  ask = TRUE,
+  env = character()
 )
 }
 \arguments{
@@ -69,6 +71,9 @@ instead we return the parsed text that would be submitted as a cron job.}
 \item{user}{The user whose cron jobs we wish to examine.}
 
 \item{ask}{Boolean; show prompt asking for validation}
+
+\item{env}{Named character; set environment variables for a cron job.
+Specify `Sys.getenv()` to inherit the variables from the current R session.}
 }
 \description{
 Generate a cron job, and pass it to crontab.


### PR DESCRIPTION
To enable something like below
This is especially important for non-ASCII users to set `LANG` for example.

``` r
cronR::cron_add(
  command = 'echo "$FOO" >> /home/atusy/cronR.log',
  frequency = 'minutely',
  id = 'test1',
  description = 'My procest 1',
  tags = c('lab', 'xyz'),
  ask=FALSE,
  env=c(FOO="BAR")
)
```

```
Adding cronjob:
---------------

## cronR job
## id:   test1
## tags: lab, xyz
## desc: My procest 1
FOO=BAR
0-59 * * * * echo "$FOO" >> /home/atusy/cronR.log
```