### PR TITLE
clear_cron: skip the -u option if user is empty

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: cronR
 Type: Package
 Title: Schedule R Scripts and Processes with the 'cron' Job Scheduler
-Version: 0.6.1
+Version: 0.6.2
 Authors@R: c(
     person("Jan", "Wijffels", role = c("aut", "cre", "cph"), email = "jwijffels@bnosac.be"), 
     person("BNOSAC", role = "cph"), 

--- a/R/cron_clear.R
+++ b/R/cron_clear.R
@@ -20,27 +20,24 @@
 #' \}
 #' }
 cron_clear <- function(ask=TRUE, user="") {
-  
-  if (user == "")
-    current_user <- Sys.getenv("USER")
-  else
-    current_user <- user
-  
   if (ask) {
-    cat( sep="", "Are you sure you want to clear all cron jobs for '", 
-      current_user, "'? [y/n]: ")
+    if (user == "")
+      cat( sep="", "Are you sure you want to clear all your cron jobs? [y/n]: ")
+    else
+      cat( sep="", "Are you sure you want to clear all cron jobs for '",
+        user, "'? [y/n]: ")
     input <- tolower(scan(what=character(), n=1, quiet=TRUE))
-    if (input == "y") {
-      ok <- system(sprintf("crontab -u %s -r", current_user))
-      if(ok == 0){
-        message("Crontab cleared.")  
-      }
-    } else {
+    if (input != "y") {
       ok <- 0
       message("No action taken.")
+      return (invisible(ok))
     }
-  } else {
-    ok <- system(sprintf("crontab -u %s -r", current_user))
   }
+  if (user == "")
+    ok <- system("crontab -r")
+  else
+    ok <- system(sprintf("crontab -u %s -r", user))
+  if (ok == 0)
+    message("Crontab cleared.")
   return (invisible(ok))
 }

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -1,6 +1,10 @@
 Package: cronR
 ================
 
+Version: 0.6.2 [2022-02-15]
+
+- Call "crontab -r" without "-u user" when the user parameter is empty.
+
 Version: 0.6.1 [2021-01-27]
 
 - cron_add gains an argument, env, which sets environment variables for a cron job by a named vector.


### PR DESCRIPTION
Red Hat based distributions use cronie (a fork of vixie-cron / isc cron)
that do not allow the use of -u for non-root users, even if it matches
the current user.

This results in the error: "must be privileged to use -u"

Call "crontab -r" without "-u user" when the user parameter is empty.

Resolves #48