### PR TITLE
Mailto

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,3 +21,4 @@ License: MIT + file LICENSE
 OS_type: unix
 SystemRequirements: cron
 RoxygenNote: 7.1.1
+Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: cronR
 Type: Package
 Title: Schedule R Scripts and Processes with the 'cron' Job Scheduler
-Version: 0.6.2
+Version: 0.6.3
 Authors@R: c(
     person("Jan", "Wijffels", role = c("aut", "cre", "cph"), email = "jwijffels@bnosac.be"), 
     person("BNOSAC", role = "cph"), 

--- a/R/cron_rscript.R
+++ b/R/cron_rscript.R
@@ -35,7 +35,7 @@ cron_rscript <- function(rscript,
   # no rscript_args are provided, return an empty character string.
   if(!rscript_args == ""){
     rscript_args <- paste(rscript_args, collapse = " ")
-    rscript_args <- paste0(rscript_args, " ")
+    rscript_args <- paste(rscript_args, " ", sep = "")
   }
   # Check to see if rscript includes absolute path to the file, if it does not, then prepend the
   # working directory to the base file name.

--- a/R/deparse_crontab.R
+++ b/R/deparse_crontab.R
@@ -17,5 +17,9 @@ deparse_crontab <- function(parsed_crontab) {
     ))
   }))
   other <- parsed_crontab$other
-  return (paste(cronR, other, sep="\n", collapse="\n"))
+  if(cronR == ""){
+    return (paste(other, "", sep="\n", collapse="\n"))
+  }else{
+    return (paste(other, cronR, "", sep="\n", collapse="\n"))  
+  }
 }

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -1,6 +1,11 @@
 Package: cronR
 ================
 
+Version: 0.6.3 [2022-05-09]
+
+- cron_rscript gains an argument, type, which allows for different command types such as those that generate an output on error. The current command type is the "default" value.
+- Changes to deparse_crontab(): all cronR jobs will be placed at the bottom of the crontab now instead of the top.
+
 Version: 0.6.2 [2022-02-16]
 
 - Call "crontab -r" without "-u user" when the user parameter is empty.

--- a/man/cron_rscript.Rd
+++ b/man/cron_rscript.Rd
@@ -12,7 +12,8 @@ cron_rscript(
   cmd = file.path(Sys.getenv("R_HOME"), "bin", "Rscript"),
   log_append = TRUE,
   log_timestamp = FALSE,
-  workdir = NULL
+  workdir = NULL,
+  output_on_error = FALSE
 )
 }
 \arguments{
@@ -30,12 +31,15 @@ cron_rscript(
 This will only work if the path to the log folder does not contain spaces.}
 
 \item{workdir}{If provided, Rscript will be run from this working directory.}
+
+\item{output_on_error}{logical, indicating if the command should also output stdout and stderr
+(in addition to sending them to the log) whenever the R script has a non-zero exit status.}
 }
 \value{
 a character string with a command which can e.g. be put as a cronjob for running a simple R script at specific timepoints
 }
 \description{
-Create a command to execute an R script which can be scheduled with cron_add where the stdin and stderr will be passed on to a log
+Create a command to execute an R script which can be scheduled with cron_add where the stdout and stderr will be passed on to a log
 }
 \examples{
 f <- system.file(package = "cronR", "extdata", "helloworld.R")

--- a/man/cron_rscript.Rd
+++ b/man/cron_rscript.Rd
@@ -13,7 +13,7 @@ cron_rscript(
   log_append = TRUE,
   log_timestamp = FALSE,
   workdir = NULL,
-  output_on_error = FALSE
+  type = c("default", "output_on_error", "output_always")
 )
 }
 \arguments{
@@ -32,8 +32,12 @@ This will only work if the path to the log folder does not contain spaces.}
 
 \item{workdir}{If provided, Rscript will be run from this working directory.}
 
-\item{output_on_error}{logical, indicating if the command should also output stdout and stderr
-(in addition to sending them to the log) whenever the R script has a non-zero exit status.}
+\item{type}{a character string specifying the type of command to generate:
+\describe{
+  \item{default}{The command will send stdout and stderr to the log file but will never output these streams.}
+  \item{outuput_always}{The command will send stdout and stderr to the log file in addtion to emitting them as an output.}
+  \item{outuput_on_error}{The command will send stdout and stderr to the log file, and it will emit them as an output when the R script has a non-zero exit status.}
+}}
 }
 \value{
 a character string with a command which can e.g. be put as a cronjob for running a simple R script at specific timepoints


### PR DESCRIPTION
##  Support Sending Email When And Only When Script Errors

- Changes the command generated by `cron_rscript()`  so that stdout & stderr generate an output when and only when the R script errors
- If the R script errors, **cron** will send an email to the address specified by `MAILTO` in *crontab*
- Logs are still generated as before with no changes to the `cron_rscript()` API
- New convention adopted via `deparse_crontab()` which always places **cronR** jobs at the bottom of the *crontab* (rather than at the beginning of the file as is the current convention) and places all non-**cronR** content at the top of the *crontab*. This prevents `MAILTO` from being placed beneath the **cronR** jobs as `MAILTO` must come before the **cron** job.
- Limitation of this implementation is that all **cronR** jobs must use the same `MAILTO` email address unless the user chooses to manually edit the file. If they do that, the next time `cron_rm()` is called, all the `MAILTO` values will be moved to the top of the file and then the last `MAILTO` would superceed all prior values ; once again the user would need to manually edit the file.
- This approach was adapted from the article [Automating R Scripts with Cron](https://stevenmortimer.com/automating-r-scripts-with-cron/).

## Other Changes

### Bug Fix
- This implementation also fixes a bug I encountered when I made repeated calls to `cron_add()` and `cron_rm()` in a crontab containing both **cronR** jobs and non-**cronR** jobs (or a `MAILTO` line).  Each time there is a round-trip between `cron_add()` and `cron_rm()` a line sperating the **cronR** jobs and the non-**cronR** content is lost. This eventially causes a problem when all of the lines seperating the **cronR** and non-**cronR** content is removed as `cron_rm()` will throw the error "new crontab file is missing newline before EOF, can't install."

### Warning Message
- Added `Encoding: UTF-8` to *DESCRIPTION* to address the warning generated by *roxygen* when running `roxygenise()`.